### PR TITLE
Introduce explicit parameter types in `flowjax.parameters` and replace `paramax` wrappers

### DIFF
--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -1,17 +1,14 @@
 """Affine bijections."""
 
 from collections.abc import Callable
-from functools import partial
 from typing import ClassVar
 
 import jax.numpy as jnp
-from jax.nn import softplus
 from jax.scipy.linalg import solve_triangular
 from jaxtyping import Array, ArrayLike, Shaped
-from paramax import AbstractUnwrappable, Parameterize, unwrap
-from paramax.utils import inv_softplus
 
 from flowjax.bijections.bijection import AbstractBijection
+from flowjax.parameters import PositiveParameter, TriangularParameter
 from flowjax.utils import arraylike_to_array
 
 
@@ -31,7 +28,7 @@ class Affine(AbstractBijection):
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
     loc: Array
-    scale: Array | AbstractUnwrappable[Array]
+    scale: PositiveParameter
 
     def __init__(
         self,
@@ -42,13 +39,15 @@ class Affine(AbstractBijection):
             *(arraylike_to_array(a, dtype=float) for a in (loc, scale)),
         )
         self.shape = scale.shape
-        self.scale = Parameterize(softplus, inv_softplus(scale))
+        self.scale = PositiveParameter(scale)
 
     def transform_and_log_det(self, x, condition=None):
-        return x * self.scale + self.loc, jnp.log(jnp.abs(self.scale)).sum()
+        return x * self.scale.value + self.loc, jnp.log(jnp.abs(self.scale.value)).sum()
 
     def inverse_and_log_det(self, y, condition=None):
-        return (y - self.loc) / self.scale, -jnp.log(jnp.abs(self.scale)).sum()
+        return (y - self.loc) / self.scale.value, -jnp.log(
+            jnp.abs(self.scale.value)
+        ).sum()
 
 
 class Loc(AbstractBijection):
@@ -82,21 +81,21 @@ class Scale(AbstractBijection):
 
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
-    scale: Array | AbstractUnwrappable[Array]
+    scale: PositiveParameter
 
     def __init__(
         self,
         scale: ArrayLike,
     ):
         scale = arraylike_to_array(scale, "scale", dtype=float)
-        self.scale = Parameterize(softplus, inv_softplus(scale))
-        self.shape = jnp.shape(unwrap(scale))
+        self.scale = PositiveParameter(scale)
+        self.shape = jnp.shape(scale)
 
     def transform_and_log_det(self, x, condition=None):
-        return x * self.scale, jnp.log(jnp.abs(self.scale)).sum()
+        return x * self.scale.value, jnp.log(jnp.abs(self.scale.value)).sum()
 
     def inverse_and_log_det(self, y, condition=None):
-        return y / self.scale, -jnp.log(jnp.abs(self.scale)).sum()
+        return y / self.scale.value, -jnp.log(jnp.abs(self.scale.value)).sum()
 
 
 class TriangularAffine(AbstractBijection):
@@ -119,7 +118,7 @@ class TriangularAffine(AbstractBijection):
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
     loc: Array
-    triangular: Array | AbstractUnwrappable[Array]
+    triangular: TriangularParameter
     lower: bool
 
     def __init__(
@@ -133,25 +132,18 @@ class TriangularAffine(AbstractBijection):
         if (arr.ndim != 2) or (arr.shape[0] != arr.shape[1]):
             raise ValueError("arr must be a square, 2-dimensional matrix.")
         dim = arr.shape[0]
-        arr = jnp.fill_diagonal(arr, inv_softplus(jnp.diag(arr)), inplace=False)
-
-        @partial(jnp.vectorize, signature="(d,d)->(d,d)")
-        def _to_triangular(arr):
-            tri = jnp.tril(arr) if lower else jnp.triu(arr)
-            return jnp.fill_diagonal(tri, softplus(jnp.diag(tri)), inplace=False)
-
-        self.triangular = Parameterize(_to_triangular, arr)
+        self.triangular = TriangularParameter(arr, lower=lower)
         self.lower = lower
         self.shape = (dim,)
         self.loc = jnp.broadcast_to(loc, (dim,))
 
     def transform_and_log_det(self, x, condition=None):
-        y = self.triangular @ x + self.loc
-        return y, jnp.log(jnp.abs(jnp.diag(self.triangular))).sum()
+        y = self.triangular.value @ x + self.loc
+        return y, jnp.log(jnp.abs(jnp.diag(self.triangular.value))).sum()
 
     def inverse_and_log_det(self, y, condition=None):
-        x = solve_triangular(self.triangular, y - self.loc, lower=self.lower)
-        return x, -jnp.log(jnp.abs(jnp.diag(self.triangular))).sum()
+        x = solve_triangular(self.triangular.value, y - self.loc, lower=self.lower)
+        return x, -jnp.log(jnp.abs(jnp.diag(self.triangular.value))).sum()
 
 
 class AdditiveCondition(AbstractBijection):

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -14,8 +14,8 @@ import equinox as eqx
 import jax.numpy as jnp
 from equinox import AbstractVar
 from jaxtyping import Array, ArrayLike
-from paramax import unwrap
 
+from flowjax.parameters import parameterize
 from flowjax.utils import _get_ufunc_signature, arraylike_to_array
 
 
@@ -53,7 +53,7 @@ def _unwrap_check_and_cast(method):
                 )
             return x
 
-        return method(unwrap(bijection), _check_x(x), _check_condition(condition))
+        return method(parameterize(bijection), _check_x(x), _check_condition(condition))
 
     return wrapper
 

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from functools import partial
+from typing import Protocol, runtime_checkable
 
 import equinox as eqx
 import jax
@@ -13,6 +14,7 @@ from jaxtyping import Array, Int, PRNGKeyArray
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.jax_transforms import Vmap
 from flowjax.masks import rank_based_mask
+from flowjax.parameters import MaskedWeightParameter
 from flowjax.utils import get_ravelled_pytree_constructor
 
 
@@ -40,7 +42,7 @@ class MaskedAutoregressive(AbstractBijection):
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
     transformer_constructor: Callable
-    masked_autoregressive_mlp: eqx.nn.MLP
+    masked_autoregressive_mlp: "MaskedMLP"
 
     def __init__(
         self,
@@ -126,11 +128,11 @@ def masked_autoregressive_mlp(
     hidden_ranks: Int[Array, " hidden_size"],
     out_ranks: Int[Array, " out_size"],
     **kwargs,
-) -> eqx.nn.MLP:
+) -> "MaskedMLP":
     """Returns an equinox multilayer perceptron, with autoregressive masks.
 
-    The weight matrices are wrapped using :class:`~paramax.wrappers.Parameterize`, which
-    will apply the masking when :class:`~paramax.wrappers.unwrap` is called on the MLP.
+    The weight matrices are wrapped with explicit masked parameter objects, which are
+    materialized by :func:`flowjax.parameters.parameterize` before use.
     For details of how the masks are formed, see https://arxiv.org/pdf/1502.03509.pdf.
 
     Args:
@@ -150,14 +152,67 @@ def masked_autoregressive_mlp(
     )
     ranks = [in_ranks, *[hidden_ranks] * mlp.depth, out_ranks]
 
-    masked_layers = []
+    masked_layers: list[MaskedLinear] = []
     for i, linear in enumerate(mlp.layers):
         mask = rank_based_mask(ranks[i], ranks[i + 1], eq=i != len(mlp.layers) - 1)
-        masked_linear = eqx.tree_at(
-            lambda linear: linear.weight,
-            linear,
-            paramax.Parameterize(jnp.where, mask, linear.weight, 0),
+        masked_layers.append(
+            MaskedLinear(
+                weight=MaskedWeightParameter(linear.weight, mask),
+                bias=linear.bias,
+            ),
         )
-        masked_layers.append(masked_linear)
+    return MaskedMLP(
+        layers=tuple(masked_layers),
+        activation=mlp.activation,
+        final_activation=mlp.final_activation,
+        use_final_bias=mlp.use_final_bias,
+    )
 
-    return eqx.tree_at(lambda mlp: mlp.layers, mlp, replace=tuple(masked_layers))
+
+@runtime_checkable
+class SupportsMaskedWeight(Protocol):
+    @property
+    def value(self) -> Array: ...
+
+
+class MaskedLinear(eqx.Module):
+    weight: SupportsMaskedWeight
+    bias: Array | None
+
+    def __call__(self, x: Array) -> Array:
+        if x.ndim != 1:
+            raise ValueError(f"Expected x.ndim == 1; got {x.ndim}.")
+        weight = self.weight.value
+        if weight.ndim != 2:
+            raise ValueError(f"Expected weight.ndim == 2; got {weight.ndim}.")
+        if weight.shape[1] != x.shape[0]:
+            raise ValueError(
+                "Input dimension mismatch in MaskedLinear: "
+                f"expected x.shape[0] == {weight.shape[1]}, got {x.shape[0]}.",
+            )
+        y = weight @ x
+        if self.bias is not None:
+            if self.bias.shape != (weight.shape[0],):
+                raise ValueError(
+                    "Bias shape mismatch in MaskedLinear: "
+                    f"expected {(weight.shape[0],)}, got {self.bias.shape}.",
+                )
+            y = y + self.bias
+        return y
+
+
+class MaskedMLP(eqx.Module):
+    layers: tuple[MaskedLinear, ...]
+    activation: Callable
+    final_activation: Callable
+    use_final_bias: bool
+
+    def __call__(self, x: Array) -> Array:
+        if len(self.layers) < 2:
+            raise ValueError("MaskedMLP expected at least two layers.")
+        for layer in self.layers[:-1]:
+            x = self.activation(layer(x))
+        x = self.layers[-1](x)
+        if self.final_activation is not None:
+            x = self.final_activation(x)
+        return x

--- a/flowjax/bijections/orthogonal.py
+++ b/flowjax/bijections/orthogonal.py
@@ -4,9 +4,9 @@ import jax.numpy as jnp
 from jax import Array
 from jax.scipy import fft
 from jaxtyping import ArrayLike
-from paramax import AbstractUnwrappable, Parameterize
 
 from flowjax.bijections.bijection import AbstractBijection
+from flowjax.parameters import UnitVectorParameter
 from flowjax.utils import arraylike_to_array
 
 
@@ -41,7 +41,7 @@ class Householder(AbstractBijection):
     """
 
     shape: tuple[int, ...]
-    unit_vec: Array | AbstractUnwrappable
+    unit_vec: UnitVectorParameter
     cond_shape = None
 
     def __init__(self, params: ArrayLike):
@@ -49,10 +49,10 @@ class Householder(AbstractBijection):
         if params.ndim != 1:
             raise ValueError("params must be a vector.")
         self.shape = params.shape
-        self.unit_vec = Parameterize(lambda x: x / jnp.linalg.norm(x), params)
+        self.unit_vec = UnitVectorParameter(params)
 
     def _householder(self, x: Array) -> Array:
-        return x - 2 * self.unit_vec * (x @ self.unit_vec)
+        return x - 2 * self.unit_vec.value * (x @ self.unit_vec.value)
 
     def transform_and_log_det(self, x: jnp.ndarray, condition: Array | None = None):
         return self._householder(x), jnp.zeros(())

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -1,12 +1,10 @@
 """Rational quadratic spline bijections (https://arxiv.org/abs/1906.04032)."""
 
-import jax
 import jax.numpy as jnp
 from jaxtyping import Array
-from paramax import Parameterize, RealToIncreasingOnInterval
-from paramax.utils import inv_softplus
 
 from flowjax.bijections.bijection import AbstractBijection
+from flowjax.parameters import IncreasingIntervalParameter, PositiveParameter
 
 
 class RationalQuadraticSpline(AbstractBijection):
@@ -25,9 +23,9 @@ class RationalQuadraticSpline(AbstractBijection):
 
     knots: int
     interval: tuple[int | float, int | float]
-    x_pos: Array
-    y_pos: Array
-    derivatives: Array
+    x_pos: IncreasingIntervalParameter
+    y_pos: IncreasingIntervalParameter
+    derivatives: PositiveParameter
     shape = ()
     cond_shape = None
 
@@ -42,26 +40,28 @@ class RationalQuadraticSpline(AbstractBijection):
         self.knots = knots
         interval = interval if isinstance(interval, tuple) else (-interval, interval)
         self.interval = interval
-        self.x_pos = RealToIncreasingOnInterval(
-            jnp.zeros(knots + 1),
+        self.x_pos = IncreasingIntervalParameter(
+            jnp.zeros(knots),
             interval=interval,
             min_width=min_width,
-            include_endpoints="both",
-        )  # type: ignore
-        self.y_pos = RealToIncreasingOnInterval(
-            jnp.zeros(knots + 1),
+        )
+        self.y_pos = IncreasingIntervalParameter(
+            jnp.zeros(knots),
             interval=interval,
             min_width=min_width,
-            include_endpoints="both",
-        )  # type: ignore
-        self.derivatives = Parameterize(
-            lambda arr: jax.nn.softplus(arr) + min_derivative,
-            jnp.full(knots + 2, inv_softplus(1 - min_derivative)),
-        )  # type: ignore
+        )
+        self.derivatives = PositiveParameter(
+            jnp.ones(knots + 2),
+            min_value=min_derivative,
+        )
 
     def transform_and_log_det(self, x, condition=None):
         # Following notation from the paper
-        x_pos, y_pos, derivatives = self.x_pos, self.y_pos, self.derivatives
+        x_pos, y_pos, derivatives = (
+            self.x_pos.value,
+            self.y_pos.value,
+            self.derivatives.value,
+        )
         in_bounds = jnp.logical_and(
             x >= jnp.array(self.interval[0]),
             x <= jnp.array(self.interval[1]),
@@ -89,7 +89,11 @@ class RationalQuadraticSpline(AbstractBijection):
 
     def inverse_and_log_det(self, y, condition=None):
         # Following notation from the paper
-        x_pos, y_pos, derivatives = self.x_pos, self.y_pos, self.derivatives
+        x_pos, y_pos, derivatives = (
+            self.x_pos.value,
+            self.y_pos.value,
+            self.derivatives.value,
+        )
         in_bounds = jnp.logical_and(
             y >= jnp.array(self.interval[0]),
             y <= jnp.array(self.interval[1]),

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -12,14 +12,12 @@ import jax.numpy as jnp
 import jax.random as jr
 from equinox import AbstractVar
 from jax import dtypes
-from jax.nn import log_softmax, softplus
 from jax.numpy import linalg
 from jax.scipy import stats as jstats
 from jax.scipy.special import logsumexp
 from jax.tree_util import tree_map
 from jaxtyping import Array, ArrayLike, PRNGKeyArray, Shaped
-from paramax import AbstractUnwrappable, Parameterize, non_trainable, unwrap
-from paramax.utils import inv_softplus
+from paramax import non_trainable
 
 from flowjax.bijections import (
     AbstractBijection,
@@ -29,6 +27,7 @@ from flowjax.bijections import (
     Scale,
     TriangularAffine,
 )
+from flowjax.parameters import LogSimplexParameter, PositiveParameter, parameterize
 from flowjax.utils import (
     _get_ufunc_signature,
     arraylike_to_array,
@@ -100,7 +99,7 @@ class AbstractDistribution(eqx.Module):
         Returns:
             Array: Jax array of log probabilities.
         """
-        self = unwrap(self)
+        self = parameterize(self)
         x = arraylike_to_array(x, err_name="x", dtype=float)
         if self.cond_shape is not None:
             condition = arraylike_to_array(condition, err_name="condition", dtype=float)
@@ -124,7 +123,7 @@ class AbstractDistribution(eqx.Module):
             condition: Conditioning variables. Defaults to None.
             sample_shape: Sample shape. Defaults to ().
         """
-        self = unwrap(self)
+        self = parameterize(self)
         if self.cond_shape is not None:
             condition = arraylike_to_array(condition, err_name="condition")
         keys = self._get_sample_keys(key, sample_shape, condition)
@@ -148,7 +147,7 @@ class AbstractDistribution(eqx.Module):
             condition: Conditioning variables. Defaults to None.
             sample_shape: Sample shape. Defaults to ().
         """
-        self = unwrap(self)
+        self = parameterize(self)
         if self.cond_shape is not None:
             condition = arraylike_to_array(condition, err_name="condition")
         keys = self._get_sample_keys(key, sample_shape, condition)
@@ -362,7 +361,7 @@ class AbstractLocScaleDistribution(AbstractTransformed):
     @property
     def scale(self):
         """Scale of the distribution."""
-        return unwrap(self.bijection.scale)
+        return self.bijection.scale.value
 
 
 class StandardNormal(AbstractDistribution):
@@ -453,7 +452,7 @@ class MultivariateNormal(AbstractTransformed):
     @property
     def covariance(self):
         """The covariance matrix."""
-        cholesky = unwrap(self.bijection.triangular)
+        cholesky = self.bijection.triangular.value
         return cholesky @ cholesky.T
 
 
@@ -494,13 +493,12 @@ class Uniform(AbstractLocScaleDistribution):
     @property
     def minval(self):
         """Minimum value of the uniform distribution."""
-        return unwrap(self.bijection.loc)
+        return parameterize(self.bijection.loc)
 
     @property
     def maxval(self):
         """Maximum value of the uniform distribution."""
-        unwrapped = unwrap(self)
-        return unwrapped.loc + unwrapped.scale
+        return parameterize(self.bijection.loc) + self.bijection.scale.value
 
 
 class _StandardGumbel(AbstractDistribution):
@@ -574,19 +572,19 @@ class _StandardStudentT(AbstractDistribution):
 
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
-    df: Array | AbstractUnwrappable[Array]
+    df: PositiveParameter
 
     def __init__(self, df: ArrayLike):
         df = arraylike_to_array(df, dtype=float)
         df = eqx.error_if(df, df <= 0, "Degrees of freedom values must be positive.")
         self.shape = jnp.shape(df)
-        self.df = Parameterize(softplus, inv_softplus(df))
+        self.df = PositiveParameter(df)
 
     def _log_prob(self, x, condition=None):
-        return jstats.t.logpdf(x, df=self.df).sum()
+        return jstats.t.logpdf(x, df=self.df.value).sum()
 
     def _sample(self, key, condition=None):
-        return jr.t(key, df=self.df, shape=self.shape)
+        return jr.t(key, df=self.df.value, shape=self.shape)
 
 
 class StudentT(AbstractLocScaleDistribution):
@@ -611,7 +609,7 @@ class StudentT(AbstractLocScaleDistribution):
     @property
     def df(self):
         """The degrees of freedom of the distribution."""
-        return unwrap(self.base_dist.df)
+        return parameterize(self.base_dist.df)
 
 
 class _StandardLaplace(AbstractDistribution):
@@ -673,7 +671,7 @@ class Exponential(AbstractTransformed):
 
     @property
     def rate(self):
-        return 1 / unwrap(self.bijection.scale)
+        return 1 / self.bijection.scale.value
 
 
 class _StandardLogistic(AbstractDistribution):
@@ -734,7 +732,7 @@ class VmapMixture(AbstractDistribution):
 
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
-    log_normalized_weights: Array | AbstractUnwrappable[Array]
+    log_normalized_weights: LogSimplexParameter
     dist: AbstractDistribution
 
     def __init__(
@@ -744,17 +742,17 @@ class VmapMixture(AbstractDistribution):
     ):
         weights = eqx.error_if(weights, weights <= 0, "Weights must be positive.")
         self.dist = dist
-        self.log_normalized_weights = Parameterize(log_softmax, jnp.log(weights))
+        self.log_normalized_weights = LogSimplexParameter(weights)
         self.shape = dist.shape
         self.cond_shape = dist.cond_shape
 
     def _log_prob(self, x, condition=None):
         log_probs = eqx.filter_vmap(lambda d: d._log_prob(x, condition))(self.dist)
-        return logsumexp(log_probs + self.log_normalized_weights)
+        return logsumexp(log_probs + self.log_normalized_weights.value)
 
     def _sample(self, key, condition=None):
         key1, key2 = jr.split(key)
-        component = jr.categorical(key1, self.log_normalized_weights)
+        component = jr.categorical(key1, self.log_normalized_weights.value)
         component_dist = tree_map(
             lambda leaf: leaf[component] if isinstance(leaf, Array) else leaf,
             tree=self.dist,
@@ -763,19 +761,21 @@ class VmapMixture(AbstractDistribution):
 
 
 class _StandardGamma(AbstractDistribution):
-    concentration: Array | AbstractUnwrappable[Array]
+    concentration: PositiveParameter
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
 
     def __init__(self, concentration: ArrayLike):
-        self.concentration = Parameterize(softplus, inv_softplus(concentration))
+        self.concentration = PositiveParameter(
+            arraylike_to_array(concentration, dtype=float)
+        )
         self.shape = jnp.shape(concentration)
 
     def _sample(self, key, condition=None):
-        return jr.gamma(key, self.concentration)
+        return jr.gamma(key, self.concentration.value)
 
     def _log_prob(self, x, condition=None):
-        return jstats.gamma.logpdf(x, self.concentration).sum()
+        return jstats.gamma.logpdf(x, self.concentration.value).sum()
 
 
 class Gamma(AbstractTransformed):
@@ -803,8 +803,8 @@ class Beta(AbstractDistribution):
         beta: The beta shape parameter.
     """
 
-    alpha: Array | AbstractUnwrappable[Array]
-    beta: Array | AbstractUnwrappable[Array]
+    alpha: PositiveParameter
+    beta: PositiveParameter
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
 
@@ -813,12 +813,12 @@ class Beta(AbstractDistribution):
             arraylike_to_array(alpha, dtype=float),
             arraylike_to_array(beta, dtype=float),
         )
-        self.alpha = Parameterize(softplus, inv_softplus(alpha))
-        self.beta = Parameterize(softplus, inv_softplus(beta))
+        self.alpha = PositiveParameter(alpha)
+        self.beta = PositiveParameter(beta)
         self.shape = alpha.shape
 
     def _sample(self, key, condition=None):
-        return jr.beta(key, self.alpha, self.beta)
+        return jr.beta(key, self.alpha.value, self.beta.value)
 
     def _log_prob(self, x, condition=None):
-        return jstats.beta.logpdf(x, self.alpha, self.beta).sum()
+        return jstats.beta.logpdf(x, self.alpha.value, self.beta.value).sum()

--- a/flowjax/parameters.py
+++ b/flowjax/parameters.py
@@ -1,0 +1,254 @@
+"""Utilities and typing protocols for explicit parameterizations."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import paramax
+from jax.tree_util import tree_map
+from jaxtyping import Array
+
+TLatent = TypeVar("TLatent")
+TValue = TypeVar("TValue")
+
+
+@runtime_checkable
+class Parameterization(Protocol[TLatent, TValue]):
+    """Protocol for explicit constrained parameter handling.
+
+    Implementations must expose:
+    - ``latent``: the underlying state.
+    - ``value``: a deterministic value computed from latent state.
+    """
+
+    latent: TLatent
+
+    @property
+    def value(self) -> TValue:
+        """Return the deterministic value associated with ``latent``."""
+
+
+@runtime_checkable
+class SupportsUnwrap(Protocol[TValue]):
+    """Protocol for explicit unwrapping of constrained parameter leaves."""
+
+    def unwrap(self) -> TValue:
+        """Return the unwrapped value."""
+
+
+def parameterize(pytree: Any):
+    """Materialize parameterizations across a pytree.
+
+    This unwraps any leaf implementing :class:`SupportsUnwrap`.
+
+    Leaves implementing :class:`Parameterization` are preserved so callers can
+    explicitly access ``leaf.value`` where required.
+    """
+
+    def _materialize(leaf):
+        if isinstance(leaf, Parameterization):
+            return leaf
+        if isinstance(leaf, SupportsUnwrap):
+            return paramax.unwrap(leaf)
+        return leaf
+
+    return tree_map(_materialize, pytree, is_leaf=_is_parameter_leaf)
+
+
+def _is_parameter_leaf(leaf) -> bool:
+    return isinstance(leaf, Parameterization | SupportsUnwrap)
+
+
+class PositiveParameter(eqx.Module):
+    """A positive parameterization using softplus."""
+
+    latent: Array
+    min_value: float
+
+    def __init__(self, value: Array, *, min_value: float = 0.0):
+        value = jnp.asarray(value, dtype=float)
+        if jnp.any(value <= min_value):
+            raise ValueError(
+                "PositiveParameter expected all values to be greater than min_value "
+                f"({min_value}); got minimum value {jnp.min(value)}.",
+            )
+        self.latent = _inv_softplus(value - min_value)
+        self.min_value = min_value
+
+    @property
+    def value(self) -> Array:
+        latent = self.latent
+        if isinstance(latent, SupportsUnwrap):
+            latent = paramax.unwrap(latent)
+        return jax.nn.softplus(latent) + self.min_value
+
+
+class TriangularParameter(eqx.Module):
+    """A triangular matrix parameterization with positive diagonal entries."""
+
+    latent: Array
+    lower: bool
+
+    def __init__(self, matrix: Array, *, lower: bool = True):
+        matrix = jnp.asarray(matrix, dtype=float)
+        if matrix.shape[-1] != matrix.shape[-2]:
+            raise ValueError("TriangularParameter expected a square matrix.")
+        diag = jnp.diagonal(matrix, axis1=-2, axis2=-1)
+        if jnp.any(diag <= 0):
+            raise ValueError(
+                "TriangularParameter expected strictly positive diagonal entries; "
+                f"got minimum diagonal value {jnp.min(diag)}.",
+            )
+
+        self.lower = lower
+        self.latent = self._replace_diagonal(matrix, _inv_softplus(diag))
+
+    @property
+    def value(self) -> Array:
+        latent = self.latent
+        if isinstance(latent, SupportsUnwrap):
+            latent = paramax.unwrap(latent)
+        triangular = jnp.tril(latent) if self.lower else jnp.triu(latent)
+        diag = jnp.diagonal(triangular, axis1=-2, axis2=-1)
+        positive_diag = jax.nn.softplus(diag)
+        return self._replace_diagonal(triangular, positive_diag)
+
+    def _replace_diagonal(self, matrix: Array, diagonal: Array) -> Array:
+        dim = matrix.shape[-1]
+        eye = jnp.eye(dim, dtype=matrix.dtype)
+        return matrix * (1 - eye) + diagonal[..., None] * eye
+
+
+class UnitVectorParameter(eqx.Module):
+    """A parameterization mapping vectors to the unit sphere."""
+
+    latent: Array
+
+    def __init__(self, value: Array):
+        value = jnp.asarray(value, dtype=float)
+        if value.ndim != 1:
+            raise ValueError("UnitVectorParameter expected a 1-dimensional vector.")
+        if jnp.all(value == 0):
+            raise ValueError("UnitVectorParameter expected a non-zero vector.")
+        self.latent = value
+
+    @property
+    def value(self) -> Array:
+        latent = self.latent
+        if isinstance(latent, SupportsUnwrap):
+            latent = paramax.unwrap(latent)
+        return latent / jnp.linalg.norm(latent)
+
+
+class IncreasingIntervalParameter(eqx.Module):
+    """A parameterization for increasing positions on a closed interval."""
+
+    latent: Array
+    interval: tuple[float, float]
+    min_width: float
+
+    def __init__(
+        self,
+        latent: Array,
+        *,
+        interval: tuple[int | float, int | float],
+        min_width: float | int = 1e-3,
+    ):
+        latent = jnp.asarray(latent, dtype=float)
+        if latent.ndim != 1:
+            raise ValueError(
+                "IncreasingIntervalParameter expected a 1-dimensional array."
+            )
+        if latent.shape[0] < 1:
+            raise ValueError("IncreasingIntervalParameter expected at least one bin.")
+
+        lo, hi = float(interval[0]), float(interval[1])
+        if not hi > lo:
+            raise ValueError(
+                "IncreasingIntervalParameter expected interval[1] > interval[0]."
+            )
+
+        num_bins = latent.shape[0]
+        min_width = float(min_width)
+        if (hi - lo) <= (num_bins * min_width):
+            raise ValueError(
+                "Interval too small for min_width constraint. "
+                f"Interval width is {hi - lo}, but requires > {num_bins * min_width}.",
+            )
+
+        self.latent = latent
+        self.interval = (lo, hi)
+        self.min_width = min_width
+
+    @property
+    def value(self) -> Array:
+        latent = self.latent
+        if isinstance(latent, SupportsUnwrap):
+            latent = paramax.unwrap(latent)
+
+        lo, hi = self.interval
+        num_bins = latent.shape[0]
+        widths = jax.nn.softmax(latent) * (hi - lo - num_bins * self.min_width)
+        widths = widths + self.min_width
+        cumsum = jnp.cumsum(widths, axis=-1)
+        return lo + jnp.concatenate(
+            (jnp.zeros((1,), dtype=latent.dtype), cumsum),
+            axis=-1,
+        )
+
+
+class LogSimplexParameter(eqx.Module):
+    """A parameterization returning log-normalized positive weights."""
+
+    latent: Array
+
+    def __init__(self, weights: Array):
+        weights = jnp.asarray(weights, dtype=float)
+        if jnp.any(weights <= 0):
+            raise ValueError("LogSimplexParameter expected strictly positive weights.")
+        self.latent = jnp.log(weights)
+
+    @property
+    def value(self) -> Array:
+        latent = self.latent
+        if isinstance(latent, SupportsUnwrap):
+            latent = paramax.unwrap(latent)
+        return jax.nn.log_softmax(latent)
+
+
+class MaskedWeightParameter(eqx.Module):
+    """Masked weight parameterization for autoregressive networks."""
+
+    latent: Array
+    mask: Array
+
+    def __init__(self, weights: Array, mask: Array):
+        weights = jnp.asarray(weights)
+        mask = jnp.asarray(mask)
+        if weights.shape != mask.shape:
+            raise ValueError(
+                "MaskedWeightParameter expected weights and mask to have the same shape; "
+                f"got {weights.shape} and {mask.shape}.",
+            )
+        if mask.dtype != jnp.bool_:
+            if not jnp.all((mask == 0) | (mask == 1)):
+                raise ValueError(
+                    "MaskedWeightParameter expected a boolean mask or a {0, 1} mask."
+                )
+            mask = mask.astype(bool)
+        self.latent = weights
+        self.mask = mask
+
+    @property
+    def value(self) -> Array:
+        latent = self.latent
+        if isinstance(latent, SupportsUnwrap):
+            latent = paramax.unwrap(latent)
+        return jnp.where(self.mask, latent, 0)
+
+def _inv_softplus(x: Array) -> Array:
+    """Inverse softplus for positive x."""
+    return x + jnp.log(-jnp.expm1(-x))

--- a/tests/test_bijections/test_masked_autoregressive.py
+++ b/tests/test_bijections/test_masked_autoregressive.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-import paramax
 from jax import random
 
 from flowjax.bijections.masked_autoregressive import masked_autoregressive_mlp
@@ -13,10 +12,9 @@ def test_masked_autoregressive_mlp():
     hidden_ranks = jnp.arange(6) % in_size
     out_ranks = jnp.arange(in_size).repeat(2)
 
-    # Extract masks before unwrapping
+    # Extract masks from explicit masked-weight parameterizations
     mlp = masked_autoregressive_mlp(in_ranks, hidden_ranks, out_ranks, depth=3, key=key)
-    mlp = paramax.unwrap(mlp)
-    masks = [layer.weight != 0 for layer in mlp.layers]
+    masks = [layer.weight.value != 0 for layer in mlp.layers]
     x = jnp.ones(in_size)
     y = mlp(x)
     assert y.shape == out_ranks.shape


### PR DESCRIPTION
### Motivation

- Replace scattered use of `paramax.Parameterize`/`unwrap` with explicit, well-typed parameter objects to make constrained parameters easier to reason about and materialize. 
- Provide reusable parameterizations for common constraints (positive, triangular with positive diagonal, unit vectors, increasing interval, log-simplex and masked weights) required by bijections and distributions.

### Description

- Add new module `flowjax.parameters` implementing `PositiveParameter`, `TriangularParameter`, `UnitVectorParameter`, `IncreasingIntervalParameter`, `LogSimplexParameter`, `MaskedWeightParameter`, a `Parameterization` protocol, and the helper `parameterize` to materialize unwrapped leaves. 
- Update bijections to use the new parameter types (e.g. `Affine`, `Scale`, `TriangularAffine`, `Householder`, `RationalQuadraticSpline`) and access concrete values via the `.value` property. 
- Replace the global unwrapping flow with `parameterize` in `_unwrap_check_and_cast` so parameterized leaves are materialized at call-time. 
- Rework masked-autoregressive construction to return a `MaskedMLP` built from `MaskedLinear` layers that use `MaskedWeightParameter` instead of `paramax` wrappers, and add a lightweight `SupportsMaskedWeight` protocol for typing. 
- Update distributions to use the new parameters (e.g. `LogSimplexParameter`, `PositiveParameter`) and to read `.value` where appropriate. 
- Update unit test `tests/test_bijections/test_masked_autoregressive.py` to inspect masks via the explicit `.value` access instead of `paramax.unwrap`.

### Testing

- Ran the updated masked autoregressive unit test with `pytest tests/test_bijections/test_masked_autoregressive.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef27ccd70c8325af477b43199c4af0)